### PR TITLE
Added transforms from mocap plates and other static markers to specific objects.

### DIFF
--- a/launch/mocap_to_kinect_static_transforms.launch
+++ b/launch/mocap_to_kinect_static_transforms.launch
@@ -1,0 +1,52 @@
+<launch>
+    
+    <arg name="use_sim_time" default="false"/>
+
+    <group ns="static_transform_publishers">
+        <!-- Note that when specifying orientation with 3 numbers, it's yaw pitch roll -->
+
+        <!-- This transform was calculated by setting the used by the folding table
+             as seen from the kinect frame to match the frame reported by mocap -->
+        <!-- node pkg="tf2_ros" type="static_transform_publisher" name="kinect2_tf_broadcaster" required="true" args="0.027532004296964008, 0.048942209950519344, -0.016327834523498286     -0.5126711573666899 0.49168739305024817   -0.4939462922935266    0.5014268164440625   /mocap_Kinect2BlockRoof_Kinect2BlockRoof   /kinect2_ir_optical_frame">
+            <param name="use_sim_time" value="$(arg use_sim_time)"/>
+        </node -->
+
+        <!-- This is the raw transform calculated from point cloud data the puts the
+             Kinect in the correct position relative to the table. We don't use this
+             transform because it is specific to the particular configuration when
+             we recorded the data. It was used however to calculate the above transform -->
+        <!--node pkg="tf2_ros" type="static_transform_publisher" name="kinect2_tf_broadcaster" required="true" args="-0.077963592813056  -0.038134521425926   1.624122269618843                0.720915512170930  -0.692935388982982   0.008126034064077  -0.007438990302292             /mocap_FoldingTableSurface_FoldingTableSurface   /kinect2_ir_optical_frame">
+            <param name="use_sim_time" value="$(arg use_sim_time)"/>
+        </node-->
+
+        <!-- This transform is used to connect the mocap data to the "kinect2_link" frame
+             that the kinect2_bridge data uses as its reference. It was calculated using
+             the above transforms and the transform between "kinect2_link" and
+             "kinect2_ir_optical_frame" as published by kinect2_bridge -->
+        <!--<node pkg="tf2_ros" type="static_transform_publisher" name="kinect2_roof_tf_broadcaster" required="true" args="0.031008404506653   0.021057223721192  -0.016030148860467   -0.506193991453260   0.500387254594431  -0.495676785109921   0.497679377872098       /mocap_Kinect2BlockRoof_Kinect2BlockRoof   /kinect2_roof_link">-->
+
+        <!-- These values were tweaked to visually match better for the MPS project-->
+        <node pkg="tf2_ros" type="static_transform_publisher" name="kinect2_roof_tf_broadcaster" required="true"
+              args="2.219   -0.327   1.993
+                   -0.718206154753868   0.693198976663552  -0.047013494809794   0.038010910697280
+                    mocap_world kinect2_roof_link">
+            <param name="use_sim_time" value="$(arg use_sim_time)"/>
+        </node>
+              <!--args="0.031008404506653   0.021057223721192  -0.030030148860467        0.499966532285212  -0.504136092343149   0.491916169558652  -0.503883666254844    /mocap_Kinect2BlockRoof_Kinect2BlockRoof   /kinect2_roof_link">-->
+
+        <!-- Tweaked by hand for visually correct data, using qhd stream -->
+        <!--<node pkg="tf2_ros" type="static_transform_publisher" name="kinect2_victor_head_tf_broadcaster" required="true"-->
+              <!--args="0.035   0.02   -0.03          0.515983100216175  -0.515983100216175   0.483488821268191  -0.483488821268191         mocap_Kinect2VictorHead_Kinect2VictorHead   kinect2_victor_head_link">-->
+            <!--<param name="use_sim_time" value="$(arg use_sim_time)"/>-->
+        <!--</node>-->
+
+        <!-- Calculated using script from robot_calibration package using the QHD channel: DON'T USE SD!!!! -->
+        <node pkg="tf2_ros" type="static_transform_publisher" name="kinect2_victor_head_tf_broadcaster" required="true"
+              args="0.031553692705093117, 0.027052715853432538, -0.027229205965475067
+                   -0.51512778  0.51795713 -0.48424314  0.48153127
+                    mocap_Kinect2VictorHead_Kinect2VictorHead   kinect2_victor_head_link">
+            <param name="use_sim_time" value="$(arg use_sim_time)"/>
+        </node>
+    </group>
+
+</launch>

--- a/launch/mocap_to_table_static_transform.launch
+++ b/launch/mocap_to_table_static_transform.launch
@@ -1,0 +1,10 @@
+<launch>
+    <arg name="use_sim_time" default="false"/>
+
+    <group ns="static_transform_publishers">
+        <node pkg="tf2_ros" type="static_transform_publisher" name="surface_location_broadcaster" required="true"
+              args="0 0 0 0 0 0 mocap_FoldingTableSurface_FoldingTableSurface table_surface">
+            <param name="use_sim_time" value="$(arg use_sim_time)"/>
+        </node>
+    </group>
+</launch>

--- a/launch/mocap_to_victor_static_transform.launch
+++ b/launch/mocap_to_victor_static_transform.launch
@@ -1,0 +1,14 @@
+<launch>
+    <arg name="use_sim_time" default="false"/>
+
+    <!--These numbers were calculated using the Matlab script in the scripts folder
+        of the victor_hardware_interface package -->
+    <group ns="static_transform_publishers">
+        <node pkg="tf2_ros" type="static_transform_publisher" name="victor_torso_tf_broadcaster" required="true"
+              args="0.019054157686541   0.003714452485092  -0.893404416219662
+                    0.001354134240471  -0.012365797547978   0.015592627363226   0.999801041879520
+                    mocap_VictorTorso_VictorTorso victor_root">
+            <param name="use_sim_time" value="$(arg use_sim_time)"/>
+        </node>
+    </group>
+</launch>


### PR DESCRIPTION
The idea is that instead of having these transforms scattered throughout multiple repos, we have them all in one place. They are not started when starting the bridge itself; each user is responsible for using just the publishers they need.